### PR TITLE
Implement handling of possible touch event

### DIFF
--- a/package/ContextMenuProvider.tsx
+++ b/package/ContextMenuProvider.tsx
@@ -52,12 +52,20 @@ export function ContextMenuProvider({
     setData(null);
   };
 
-  const showContextMenu: ShowContextMenuFunction = (content, options) => (e) => {
+  const showContextMenu: ShowContextMenuFunction = (content, options) => (e: React.MouseEvent | React.TouchEvent) => {
     e.preventDefault();
     e.stopPropagation();
+
+    const x = "touches" in e
+      ? e.touches[0].clientX
+      : e.clientX;
+    const y = "touches" in e
+      ? e.touches[0].clientY
+      : e.clientY;
+
     setData({
-      x: e.clientX,
-      y: e.clientY,
+      x,
+      y,
       content,
       zIndex: options?.zIndex || zIndex,
       className: options?.className,


### PR DESCRIPTION
Rationale: in rare cases where a `TouchEvent` is passed, the coordinate of the touch can be accessed to correctly set the position of the context menu.

This was implemented in one of my applications as a fork to workaround with iOS limitation ([where the `contextmenu` event is not fired](https://bugs.webkit.org/show_bug.cgi?id=213953)) to solve #151. My workaround directly calls the event that would otherwise have been assigned to `onContextMenu`.

From my understanding, my change should be fully backwards compatible, and has no effect on existing implementations using this package.

I'm relatively inexperienced in TypeScript, so please feel free to advise and provide suggestion as needed.